### PR TITLE
Delete llama-stack-k8s-operator images in RHOAI 2.23 and 2.24

### DIFF
--- a/rhoai-2.23.md
+++ b/rhoai-2.23.md
@@ -64,7 +64,6 @@
     - quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
     - quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
     - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
-    - quay.io/opendatahub/llama-stack-k8s-operator@sha256:f8f66ec02e7f59e510cb20eebfe0c1f6d41b62a9276c6e8e703d258f93d49119
     - quay.io/modh/must-gather@sha256:d0404c401d4c619a7a41deeee798b2ec9beab8be6b70d0434bdcf043a0924330
 
 
@@ -183,7 +182,6 @@ mirror:
     - name: quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
     - name: quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
     - name: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
-    - name: quay.io/opendatahub/llama-stack-k8s-operator@sha256:f8f66ec02e7f59e510cb20eebfe0c1f6d41b62a9276c6e8e703d258f93d49119
     - name: quay.io/modh/must-gather@sha256:d0404c401d4c619a7a41deeee798b2ec9beab8be6b70d0434bdcf043a0924330
 
 

--- a/rhoai-2.24.md
+++ b/rhoai-2.24.md
@@ -64,7 +64,6 @@
     - quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
     - quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
     - registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
-    - quay.io/opendatahub/llama-stack-k8s-operator@sha256:f8f66ec02e7f59e510cb20eebfe0c1f6d41b62a9276c6e8e703d258f93d49119
     - quay.io/modh/must-gather@sha256:413dd7e38522873c8c0839832d818bbcc384b80d559001d0fc4adfbf6cff2a2b
 
 
@@ -183,7 +182,6 @@ mirror:
     - name: quay.io/modh/training@sha256:883739b576b485d79966d8c894fdd9ebebd226605a2abe8b33593ca67c87a394
     - name: quay.io/modh/training@sha256:6cdae840fa029da33cccab620367e82404d24ddf67762eb4537a9bffe1af306d
     - name: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e
-    - name: quay.io/opendatahub/llama-stack-k8s-operator@sha256:f8f66ec02e7f59e510cb20eebfe0c1f6d41b62a9276c6e8e703d258f93d49119
     - name: quay.io/modh/must-gather@sha256:413dd7e38522873c8c0839832d818bbcc384b80d559001d0fc4adfbf6cff2a2b
 
 


### PR DESCRIPTION
Starting in RHOAI 2.22, the upstream llama-stack-k8s-operator are no longer used. The image is now part of RHOAI's build: https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/de4bd472573f468d4de0b853065f2cafc61dce33/bundle/manifests/rhods-operator.clusterserviceversion.yaml#L1630