### PR TITLE
Remove data-processing image from RHOAI 3.5 FIPS scan list

### DIFF
--- a/rhoai-3.5.md
+++ b/rhoai-3.5.md
@@ -28,7 +28,6 @@
     - registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
     - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
     - registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
-    - quay.io/opendatahub/data-processing@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d
     - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
     - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9
     - registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:496b9ff80594d486f594bba69652c3ae4445265b94a44995b25f5ebd1e5767b3
@@ -109,7 +108,6 @@ mirror:
     - name: registry.redhat.io/rhoai/odh-pipeline-runtime-pytorch-rocm-py312-rhel9@sha256:d9c32296f9b8b6b9b0fccaafe0e910d96e3e700fa14876f19ad7570523b4b384
     - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-rocm-py312-rhel9@sha256:a4cfdf3f66e855efd3809f83e806becd5f30a8e18e73ef157f81aab37f07cd47
     - name: registry.redhat.io/rhoai/odh-pipeline-runtime-tensorflow-cuda-py312-rhel9@sha256:917272fc0483b20ac426626f5ee5bcdcbc4c88b5bbdbf00cf00a7a59d6bf5686
-    - name: quay.io/opendatahub/data-processing@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d
     - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cpu-py312-rhel9@sha256:01b22d2179dfa4cb57ff042a2c87c9082e2c57f331b818218b690c9a747b168e
     - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-cuda-py312-rhel9@sha256:8bacb849ae17424c4b613ed50089ae24b7ea69e92cdb4f558f561d2031e153b9
     - name: registry.redhat.io/rhoai/odh-workbench-jupyter-minimal-rocm-py312-rhel9@sha256:496b9ff80594d486f594bba69652c3ae4445265b94a44995b25f5ebd1e5767b3


### PR DESCRIPTION
## Summary

Remove `quay.io/opendatahub/data-processing` from the RHOAI 3.5 additional images list in `rhoai-3.5.md`.

This image is a **test workload** used internally for SparkPi in disconnected CI (driver image for air-gapped environments). It is **not** a customer-shipped product image and is not part of the RHOAI FBC catalog.

The [FIPS compliance scan](https://github.com/red-hat-data-services/fips-compliance) reads additional images from `rhoai-{VERSION}.md` and was flagging this image. Removing it from this file stops the scan from treating it as a release image that must be FIPS-compliant.

**What is intentionally unchanged:** the image remains in `rhoai-disconnected-images.yaml` (via `rhoai-additional-images`) so disconnected test infra can still mirror it to the bastion registry for SparkPi tests.

## Motivation

- FIPS scan source: [rhoai-3.5.md](https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-3.5.md) (referenced by [fips-compliance](https://github.com/red-hat-data-services/fips-compliance))
- Test image built from spark-operator CI: `quay.io/opendatahub/data-processing` (used in SparkPi / disconnected tests)
- Prior spark-operator binary FIPS work ([red-hat-data-services/spark-operator#140](https://github.com/red-hat-data-services/spark-operator/pull/140)) is separate — that fixed the **operator binary**, not this test workload image

## Changes

- Removed `quay.io/opendatahub/data-processing@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d` from:
  - the **Additional images** section
  - the **ImageSetConfiguration** example block